### PR TITLE
Update homepage image and resume

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
     <main class="pt-20">
         <!-- Hero -->
         <section id="home" class="min-h-screen flex flex-col justify-center items-center text-center bg-cover bg-center" style="background-image:url('https://source.unsplash.com/1600x900/?dark,workspace');">
+            <img src="profile.png" alt="Profile picture" class="w-40 h-40 rounded-full mx-auto mb-4 border-4 border-blue-500 shadow-lg">
             <h1 class="text-4xl md:text-6xl font-bold mb-4" data-lang="hero-title">Software Developer & AI Enthusiast</h1>
             <div class="space-x-4">
                 <a href="#resume" class="btn">Resume</a>
@@ -90,35 +91,11 @@
 
         <!-- Resume -->
         <section id="resume" class="py-20 bg-black" data-aos="fade-up">
-            <div class="container mx-auto grid md:grid-cols-2 gap-10">
-                <div>
-                    <h2 class="text-3xl font-bold mb-4" data-lang="resume-title">Resume</h2>
-                    <h3 class="font-semibold" data-lang="software-skills">Software Skills</h3>
-                    <div class="mb-4">
-                        <p class="mb-1">JavaScript</p>
-                        <div class="progress bg-gray-700"><div class="bar" style="width: 80%"></div></div>
-                        <p class="mb-1">Python</p>
-                        <div class="progress bg-gray-700"><div class="bar" style="width: 90%"></div></div>
-                    </div>
-                    <h3 class="font-semibold" data-lang="languages">Languages</h3>
-                    <ul class="list-disc ml-5 mb-4">
-                        <li>English</li>
-                        <li>Portuguese</li>
-                    </ul>
-                    <h3 class="font-semibold" data-lang="personal-skills">Personal Skills</h3>
-                    <p>Teamwork, Creativity, Problem Solving</p>
-                </div>
-                <div>
-                    <h3 class="font-semibold mb-2" data-lang="experience">Experience & Education</h3>
-                    <ul class="timeline">
-                        <li>
-                            <span data-lang="exp1">2022 - Present: Developer at Company</span>
-                        </li>
-                        <li>
-                            <span data-lang="edu1">2018 - 2022: BSc in Computer Science</span>
-                        </li>
-                    </ul>
-                </div>
+            <div class="container mx-auto text-center">
+                <h2 class="text-3xl font-bold mb-8" data-lang="resume-title">Resume</h2>
+                <a href="CaioMontilhaCSResume2025Updated.pdf" download>
+                    <img src="CaioResumeCS.png" alt="Resume preview" class="mx-auto cursor-pointer transform transition-transform hover:scale-105 w-64">
+                </a>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- show profile.png at the top of the hero section
- simplify resume section to show a clickable preview image

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6864b7baf8f8832f99acef8625d27979